### PR TITLE
Fix underflow (below 1e-9) bug.

### DIFF
--- a/ReactKitCalculator/Calculator.swift
+++ b/ReactKitCalculator/Calculator.swift
@@ -480,7 +480,7 @@ public class Calculator
         
         self.outputSignal =
             numBuildSignal
-                .map { _calculatorString($0!, rtrims: false) }   // output `calculatorString` to show commas & exponent, and also suffixed `.Point`+`.Num0`s if needed
+                .map { _calculatorString(raw: $0!, rtrims: false) }   // output `calculatorString` to show commas & exponent, and also suffixed `.Point`+`.Num0`s if needed
                 .merge(precalculatingSignal)
                 .peek { println("outputSignal ---> \($0)") }
         

--- a/ReactKitCalculator/Helper.swift
+++ b/ReactKitCalculator/Helper.swift
@@ -10,8 +10,7 @@ import Foundation
 import ReactKit
 
 let MAX_DIGIT_FOR_NONEXPONENT = 9
-let MIN_EXPONENT = 8
-let DECIMAL_PRECISION = 8
+let MIN_EXPONENT = 9
 let SIGNIFICAND_DIGIT = 7
 let COMMA_SEPARATOR = ","
 
@@ -38,6 +37,7 @@ func _scientificNotation(num: Double) -> ScientificNotation
     
     let significand = num * pow(10.0, Double(-exponent))
     
+//    println("_scientificNotation(\(num)) = \((significand, exponent))")
     return (significand, exponent)
 }
 
@@ -50,9 +50,11 @@ func _scientificNotation(num: Double) -> ScientificNotation
 /// - inf -> "inf"
 /// - NaN -> "nan"
 ///
-func _calculatorString(numString: NSString, rtrims rtrimsSuffixedPointAndZeros: Bool = true) -> String
+func _calculatorString(_ num: Double? = nil, raw numString: NSString? = nil, rtrims rtrimsSuffixedPointAndZeros: Bool = true) -> String
 {
-    let num = numString.doubleValue
+    precondition(num != nil || numString != nil, "Either `num` or `numString` must be non-nil.")
+    
+    let num = num ?? numString!.doubleValue
     
     // return "inf" or "nan" if needed
     if !num.isFinite { return "\(num)" }
@@ -109,6 +111,7 @@ func _calculatorString(numString: NSString, rtrims rtrimsSuffixedPointAndZeros: 
     }
     // add commas for integer-part
     else {
+        let numString = numString ?? NSString(format: "%0.\(MIN_EXPONENT)f", num)
         string = _commaString(numString)
         
         if rtrimsSuffixedPointAndZeros {
@@ -120,10 +123,8 @@ func _calculatorString(numString: NSString, rtrims rtrimsSuffixedPointAndZeros: 
 }
 
 /// e.g. "12345.67000" -> "12,345.67000" (used for number with non-exponent only)
-func _commaString(numString: NSString) -> String
+func _commaString(var string: NSString) -> String
 {
-    var string = numString
-    
     // split by `.Point`
     let splittedStrings = string.componentsSeparatedByString(Calculator.Key.Point.rawValue)
     if let integerString = splittedStrings.first as? String {
@@ -181,8 +182,7 @@ extension Double
 {
     var calculatorString: String
     {
-        let numString = NSString(format: "%0.\(DECIMAL_PRECISION)f", self) // NOTE: `%f` will never print exponent
-        return _calculatorString(numString, rtrims: true)
+        return _calculatorString(self, rtrims: true)
     }
 }
 

--- a/ReactKitCalculatorTests/OutputSpec.swift
+++ b/ReactKitCalculatorTests/OutputSpec.swift
@@ -615,6 +615,30 @@ class OutputSpec: QuickSpec
             
         }
         
+        describe("underflow") {
+            
+            it("`. 1 * = = = = = = = = * = `") {
+                
+                p.input = "."
+                p.input = "1"
+                p.input = "*"
+                for _ in 0..<7 {
+                    p.input = "="
+                }
+                
+                expect(p.output!).to(equal("0.00000001"))
+                
+                p.input = "="
+                expect(p.output!).to(equal("1e-9"))
+                
+                p.input = "*"
+                p.input = "="
+                expect(p.output!).to(equal("1e-18"))
+                
+            }
+            
+        }
+        
         // TODO: add bracket feature
 //        describe("bracket") {
 //        


### PR DESCRIPTION
There was a bug when trying 0.1 \* 0.1 \* ...,
which outputted as `0.01`, `0.001`, ... , `0.0000001`, `1e-8`, `1e-9`, then suddenly `0`.
- [x] below `1e-9` should be printed.
- [x] `1e-8` is wrong and should print as `0.00000001`
