### PR TITLE
Fix 1e-8 bug (significand=10 bug)

### DIFF
--- a/ReactKitCalculator/Helper.swift
+++ b/ReactKitCalculator/Helper.swift
@@ -35,7 +35,18 @@ func _scientificNotation(num: Double) -> ScientificNotation
         }
     }
     
-    let significand = num * pow(10.0, Double(-exponent))
+    var significand = num * pow(10.0, Double(-exponent))
+    
+    //
+    // NOTE:
+    // Due to rounding of floating-point,
+    // accumulating `exponent` might fail at this point (`significand` becomes `10.0`),
+    // so adjust them if needed.
+    //
+    if significand == 10.0 {
+        significand = 1.0
+        exponent++
+    }
     
 //    println("_scientificNotation(\(num)) = \((significand, exponent))")
     return (significand, exponent)
@@ -79,19 +90,7 @@ func _calculatorString(_ num: Double? = nil, raw numString: NSString? = nil, rtr
             string = "\(significand)"
         }
         else {
-            //
-            // NOTE: 
-            // Due to rounding of floating-point,
-            // `NSString(format:)` (via `doubleValue.calculatorString`) is not capable of
-            // printing very long decimal value e.g. `9.999...` as-is 
-            // (expecting "9.999..." but often returns "10"),
-            // even when higher decimal-precision is given.
-            //
             string = _rtrimFloatString(significand.calculatorString)
-            if string == "10" {
-                string = "1"
-                exponent++
-            }
             
             if string.length > SIGNIFICAND_DIGIT + 1 {  // +1 for `.Point`
                 string = string.substringToIndex(SIGNIFICAND_DIGIT + 1)

--- a/ReactKitCalculatorTests/OutputSpec.swift
+++ b/ReactKitCalculatorTests/OutputSpec.swift
@@ -625,7 +625,6 @@ class OutputSpec: QuickSpec
                 for _ in 0..<7 {
                     p.input = "="
                 }
-                
                 expect(p.output!).to(equal("0.00000001"))
                 
                 p.input = "="
@@ -634,6 +633,26 @@ class OutputSpec: QuickSpec
                 p.input = "*"
                 p.input = "="
                 expect(p.output!).to(equal("1e-18"))
+                
+            }
+            
+            it("`. 0 0 0 0 0 0 0 1 * 0 . 1 = `") {
+                
+                p.input = "."
+                for _ in 0..<7 {
+                    p.input = "0"
+                }
+                p.input = "1"
+                expect(p.output!).to(equal("0.00000001"))
+                
+                p.input = "*"
+                expect(p.output!).to(equal("0.00000001"))
+                
+                p.input = "0"
+                p.input = "."
+                p.input = "1"
+                p.input = "="
+                expect(p.output!).to(equal("1e-9"))
                 
             }
             


### PR DESCRIPTION
Inputting "0.00000001" should print as-is, not `1e-8`.
