### PR TITLE
Fix Key.PlusMinus + Key.Num0 displaying "-00"

### DIFF
--- a/ReactKitCalculator/Calculator.swift
+++ b/ReactKitCalculator/Calculator.swift
@@ -273,11 +273,14 @@ public class Calculator
                         
                         // numKey except `.Point` (NOTE: `case .Point` declared above)
                         case let numKey where contains(Key.numKeys(), numKey):
-                            if acc == Key.Num0.rawValue {
-                                return newKey.rawValue  // e.g. "0" -> "1" will be "1"
+                            if acc == Key.Minus.rawValue + Key.Num0.rawValue {
+                                return Key.Minus.rawValue + newKey.rawValue  // e.g. "-0" then "1" will be "-1"
+                            }
+                            else if acc == Key.Num0.rawValue {
+                                return newKey.rawValue  // e.g. "0" then "1" will be "1"
                             }
                             else {
-                                return (accumulatedString ?? "")  + newKey.rawValue // e.g. "12" -> "3" will be "123"
+                                return (accumulatedString ?? "")  + newKey.rawValue // e.g. "12" then "3" will be "123"
                             }
                         
                         case .PlusMinus:

--- a/ReactKitCalculatorTests/OutputSpec.swift
+++ b/ReactKitCalculatorTests/OutputSpec.swift
@@ -139,6 +139,29 @@ class OutputSpec: QuickSpec
                     
                 }
                 
+                it("`± 0` should print `-0`") {
+                    
+                    p.input = "±"
+                    expect(p.output!).to(equal("-0"))
+                    
+                    p.input = "0"
+                    expect(p.output!).to(equal("-0"))
+                    
+                }
+                
+                it("`± 0 1` should print `-1`") {
+                    
+                    p.input = "±"
+                    expect(p.output!).to(equal("-0"))
+                    
+                    p.input = "0"
+                    expect(p.output!).to(equal("-0"))
+                    
+                    p.input = "1"
+                    expect(p.output!).to(equal("-1"))
+                    
+                }
+                
                 it("`1 ±` should print `-1`") {
                     
                     p.input = "1"


### PR DESCRIPTION
This pull request will fix #7 where 
- `± 0` was printing `-00` but should print `-0`
- `± 0 1` was printing `-001` but should print `-1`
